### PR TITLE
fix: Replaced with correct api url

### DIFF
--- a/src/config/cierra-connect.php
+++ b/src/config/cierra-connect.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'api_url' => 'http://127.0.0.1:8000/api/gateway',
+    'api_url' => 'https://connect.cierra.io/api/gateway',
     'key' => env('CIERRA_CONNECT_KEY', null),
 ];


### PR DESCRIPTION
Added `https://connect.cierra.io` as default value for API url